### PR TITLE
存在しない section や stack-view-row の ID をパラメータで指定することを許可する

### DIFF
--- a/lib/thinreports/core/errors.rb
+++ b/lib/thinreports/core/errors.rb
@@ -12,12 +12,6 @@ module Thinreports
       end
     end
 
-    class UnknownSectionId < Basic
-      def initialize(section_type, section_id)
-        super(":#{section_id} is not defined in #{section_type}")
-      end
-    end
-
     class UnknownShapeType < Basic
     end
 

--- a/lib/thinreports/section_report/builder/report_builder.rb
+++ b/lib/thinreports/section_report/builder/report_builder.rb
@@ -41,10 +41,6 @@ module Thinreports
             when :footer then schema.footers
             end
 
-          sections_params.each_key do |key|
-            raise Thinreports::Errors::UnknownSectionId.new(section_type, key) unless sections_schemas.has_key? key
-          end
-
           sections_schemas.each_with_object([]) do |(section_id, section_schema), sections|
             section_params = sections_params[section_id.to_sym] || {}
             next unless section_enabled?(section_schema, section_params)
@@ -59,7 +55,7 @@ module Thinreports
             detail_id = detail_params[:id].to_sym
             detail_schema = schema.details[detail_id]
 
-            raise Thinreports::Errors::UnknownSectionId.new(:detail, detail_id) unless detail_schema
+            next unless detail_schema
 
             items = build_items(detail_schema, detail_params[:items] || {})
             details << ReportData::Section.new(detail_schema, items, detail_params[:min_height])

--- a/lib/thinreports/section_report/builder/stack_view_builder.rb
+++ b/lib/thinreports/section_report/builder/stack_view_builder.rb
@@ -15,9 +15,6 @@ module Thinreports
           rows_schema = item.internal.format.rows
 
           schema_row_ids = rows_schema.map {|row_schema| row_schema.id.to_sym}.to_set
-          rows_params.each_key do |row_id|
-            raise Thinreports::Errors::UnknownSectionId.new(:row, row_id) unless schema_row_ids.include? row_id
-          end
 
           rows = []
           rows_schema.each do |row_schema|

--- a/test/features/section_report_basic/test_feature.rb
+++ b/test/features/section_report_basic/test_feature.rb
@@ -14,12 +14,24 @@ class TestSectionReportBasicFeature < FeatureTest
       params: {
         groups: [
           {
+            headers: {
+              nonexistent_header: {
+                items: {
+                  any_item: 'nonexistent sections and items within them are ignored'
+                }
+              }
+            },
             details: build_details,
             footers: {
               overall: {
                 items: {
                   number_of_items: @categories.sum { |category| category.items.count },
                   number_of_categories: @categories.count
+                }
+              },
+              nonexistent_footer: {
+                items: {
+                  any_item: 'nonexistent sections and items within them are ignored'
                 }
               }
             }
@@ -39,6 +51,12 @@ class TestSectionReportBasicFeature < FeatureTest
         id: 'item_category',
         items: {
           category_name: category.name
+        }
+      }
+      details << {
+        id: 'nonexistent_detail',
+        items: {
+          any_item: 'nonexistent sections and items within them are ignored'
         }
       }
       category.items.each do |item|

--- a/test/features/section_report_stack_view/test_feature.rb
+++ b/test/features/section_report_stack_view/test_feature.rb
@@ -30,6 +30,11 @@ class TestSectionReportStackViewFeature < FeatureTest
                       },
                       row3: {
                         display: false
+                      },
+                      nonexistent_row: {
+                        items: {
+                          any_item: 'nonexistent rows and items within them are ignored'
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
## 概要

現状、存在しない item の ID の指定は許可しており、下記のようにパラメータで指定された場合でもエラーは発生せず無視される。

```ruby
params = {
  headers: {
    header_id: {
      items: {
        nonexistent_item_id: 'value'
      }
    }
  # ...
}
```

しかし、section や stack-view-row の存在しない ID を指定した場合は `UnknownSectionId` 例外が発生する。

機能を統一するため、section や stack-view-row についても、存在しない ID の指定を許可し、エラーが発生しないようにする。

## 別途対応する

存在しない ID を指定したときのテストケースは、一旦既存の example に追加している。しかし、これは適切な対応ではないため、別途テストケースを修正する。